### PR TITLE
Scroll to top/bottom

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -45,6 +45,41 @@ export default class VimReadingViewNavigation extends Plugin {
 			}
 			return true;
 		});
+        this.navScope.register([], 'g', (evt: KeyboardEvent) => {
+            const leaf = app.workspace.getActiveViewOfType(MarkdownView);
+			if (
+				leaf.getMode() === 'preview' &&
+				this.displayValue(leaf) === 'none' &&
+                evt.key === 'g'
+			) {
+				this.scrollTop(leaf);
+				return false;
+			}
+			return true;
+		});
+		this.navScope.register([], 'g', (evt: KeyboardEvent) => {
+			const leaf = app.workspace.getActiveViewOfType(MarkdownView);
+			if (
+				leaf.getMode() === 'preview' &&
+				this.displayValue(leaf) === 'none' &&
+                evt.key === 'G'
+			) {
+				this.scrollBottom(leaf);
+				return false;
+			}
+			return true;
+		});
+		this.navScope.register(['Shift'], 'g', (evt: KeyboardEvent) => {
+			const leaf = app.workspace.getActiveViewOfType(MarkdownView);
+			if (
+				leaf.getMode() === 'preview' &&
+				this.displayValue(leaf) === 'none'
+			) {
+				this.scrollBottom(leaf);
+				return false;
+			}
+			return true;
+		});
 		app.keymap.pushScope(this.navScope);
 
 		console.log('Vim Reading View Navigation loaded.');
@@ -75,6 +110,22 @@ export default class VimReadingViewNavigation extends Plugin {
 		const scroll = this.getScroll(leaf);
 		leaf.previewMode.applyScroll(scroll - this.settings.scrollDifference);
 	}
+
+    scrollTop(leaf: MarkdownView) {
+        leaf.previewMode.applyScroll(0);
+	}
+
+    scrollBottom(leaf: MarkdownView) {
+        let scroll = this.getScroll(leaf);
+        leaf.previewMode.applyScroll(scroll + this.settings.scrollDifference);
+        let newScroll = this.getScroll(leaf);
+
+        while (newScroll != scroll) {
+            scroll = this.getScroll(leaf);
+            leaf.previewMode.applyScroll(scroll + this.settings.scrollDifference);
+            newScroll = this.getScroll(leaf);
+        }
+    }
 
 	async loadSettings() {
 		this.settings = Object.assign(

--- a/src/main.ts
+++ b/src/main.ts
@@ -135,7 +135,7 @@ export default class VimReadingViewNavigation extends Plugin {
         let newScroll = this.getScroll(leaf);
 
         while (newScroll != scroll) {
-            scroll = this.getScroll(leaf);
+            scroll = newScroll;
             leaf.previewMode.applyScroll(scroll + this.settings.scrollDifference);
             newScroll = this.getScroll(leaf);
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,121 +1,135 @@
 import {
-	App,
-	MarkdownView,
-	Notice,
-	Plugin,
-	PluginSettingTab,
-	Scope,
-	Setting,
+    App,
+    MarkdownView,
+    Notice,
+    Plugin,
+    PluginSettingTab,
+    Scope,
+    Setting,
 } from 'obsidian';
 
 interface VimScrollSetting {
-	scrollDifference: number;
+    scrollDifference: number;
 }
 
 const DEFAULT_SETTINGS: VimScrollSetting = { scrollDifference: 1 };
 
 export default class VimReadingViewNavigation extends Plugin {
-	settings: VimScrollSetting;
-	navScope: Scope;
+    settings: VimScrollSetting;
+    navScope: Scope;
 
-	async onload() {
-		await this.loadSettings();
-		this.addSettingTab(new VimScrollSettingTab(this.app, this));
+    async onload() {
+        await this.loadSettings();
+        this.addSettingTab(new VimScrollSettingTab(this.app, this));
+        this.navScope = new Scope(app.scope);
 
-		this.navScope = new Scope(app.scope);
-		this.navScope.register([], 'j', (evt: KeyboardEvent) => {
-			const leaf = app.workspace.getActiveViewOfType(MarkdownView);
-			if (
-				leaf.getMode() === 'preview' &&
-				this.displayValue(leaf) === 'none'
-			) {
-				this.scrollDown(leaf);
-				return false;
-			}
-			return true;
-		});
-		this.navScope.register([], 'k', (evt: KeyboardEvent) => {
-			const leaf = app.workspace.getActiveViewOfType(MarkdownView);
-			if (
-				leaf.getMode() === 'preview' &&
-				this.displayValue(leaf) === 'none'
-			) {
-				this.scrollUp(leaf);
-				return false;
-			}
-			return true;
-		});
+        // Scroll down
+        this.navScope.register([], 'j', (evt: KeyboardEvent) => {
+            const leaf = app.workspace.getActiveViewOfType(MarkdownView);
+            if (
+                leaf.getMode() === 'preview' &&
+                this.displayValue(leaf) === 'none'
+            ) {
+                this.scrollDown(leaf);
+                return false;
+            }
+            return true;
+        });
+
+        // Scroll up
+        this.navScope.register([], 'k', (evt: KeyboardEvent) => {
+            const leaf = app.workspace.getActiveViewOfType(MarkdownView);
+            if (
+                leaf.getMode() === 'preview' &&
+                this.displayValue(leaf) === 'none'
+            ) {
+                this.scrollUp(leaf);
+                return false;
+            }
+            return true;
+        });
+
+        // Jump to top
+        let keyArray: string[] = [];
+        const jumpTopEvent = (event: KeyboardEvent) => {
+            const leaf = app.workspace.getActiveViewOfType(MarkdownView);
+            if (
+                leaf.getMode() === 'preview' &&
+                this.displayValue(leaf) === 'none'
+            ) {
+                event.preventDefault();
+                if (event.key != 'g') {
+                    keyArray = [];
+                } else {
+                    keyArray.push(event.key);
+                    if (keyArray.length === 2) {
+                        leaf.previewMode.applyScroll(0);
+                        keyArray = [];
+                    }
+                }
+            }
+        }
+        addEventListener('keydown', jumpTopEvent, { capture: true });
+
+        // Jump to bottom
+        //  1st evt registers g when CapsLock is on
+        //  2nd evt registers Shift+g
         this.navScope.register([], 'g', (evt: KeyboardEvent) => {
             const leaf = app.workspace.getActiveViewOfType(MarkdownView);
-			if (
-				leaf.getMode() === 'preview' &&
-				this.displayValue(leaf) === 'none' &&
-                evt.key === 'g'
-			) {
-				this.scrollTop(leaf);
-				return false;
-			}
-			return true;
-		});
-		this.navScope.register([], 'g', (evt: KeyboardEvent) => {
-			const leaf = app.workspace.getActiveViewOfType(MarkdownView);
-			if (
-				leaf.getMode() === 'preview' &&
-				this.displayValue(leaf) === 'none' &&
+            if (
+                leaf.getMode() === 'preview' &&
+                this.displayValue(leaf) === 'none' &&
                 evt.key === 'G'
-			) {
-				this.scrollBottom(leaf);
-				return false;
-			}
-			return true;
-		});
-		this.navScope.register(['Shift'], 'g', (evt: KeyboardEvent) => {
-			const leaf = app.workspace.getActiveViewOfType(MarkdownView);
-			if (
-				leaf.getMode() === 'preview' &&
-				this.displayValue(leaf) === 'none'
-			) {
-				this.scrollBottom(leaf);
-				return false;
-			}
-			return true;
-		});
-		app.keymap.pushScope(this.navScope);
+            ) {
+                this.jumpBottom(leaf);
+                return false;
+            }
+            return true;
+        });
+        this.navScope.register(['Shift'], 'g', (evt: KeyboardEvent) => {
+            const leaf = app.workspace.getActiveViewOfType(MarkdownView);
+            if (
+                leaf.getMode() === 'preview' &&
+                this.displayValue(leaf) === 'none'
+            ) {
+                this.jumpBottom(leaf);
+                return false;
+            }
+            return true;
+        });
 
-		console.log('Vim Reading View Navigation loaded.');
-	}
+        app.keymap.pushScope(this.navScope);
+        console.log('Vim Reading View Navigation loaded.');
+    }
 
-	displayValue(leaf: MarkdownView): string {
-		return leaf.contentEl
-			.getElementsByClassName('markdown-reading-view')[0]
-			.getElementsByClassName('document-search-container')[0]
-			.getCssPropertyValue('display');
-	}
+    displayValue(leaf: MarkdownView): string {
+        return leaf.contentEl
+            .getElementsByClassName('markdown-reading-view')[0]
+            .getElementsByClassName('document-search-container')[0]
+            .getCssPropertyValue('display');
+    }
 
-	async onunload() {
-		app.keymap.popScope(this.navScope);
-		console.log('Vim Reading View Navigation unloaded.');
-	}
+    async onunload() {
+        app.keymap.popScope(this.navScope);
+        removeEventListener('keydown', this.jumpTopEvent, { capture: true });
+        console.log('Vim Reading View Navigation unloaded.');
+    }
 
-	getScroll(leaf: MarkdownView): number {
-		return leaf.previewMode.getScroll();
-	}
+    getScroll(leaf: MarkdownView): number {
+        return leaf.previewMode.getScroll();
+    }
 
-	scrollDown(leaf: MarkdownView) {
-		const scroll = this.getScroll(leaf);
-		leaf.previewMode.applyScroll(scroll + this.settings.scrollDifference);
-	}
+    scrollDown(leaf: MarkdownView) {
+        const scroll = this.getScroll(leaf);
+        leaf.previewMode.applyScroll(scroll + this.settings.scrollDifference);
+    }
 
-	scrollUp(leaf: MarkdownView) {
-		const scroll = this.getScroll(leaf);
-		leaf.previewMode.applyScroll(scroll - this.settings.scrollDifference);
-	}
+    scrollUp(leaf: MarkdownView) {
+        const scroll = this.getScroll(leaf);
+        leaf.previewMode.applyScroll(scroll - this.settings.scrollDifference);
+    }
 
-    scrollTop(leaf: MarkdownView) {
-        leaf.previewMode.applyScroll(0);
-	}
-
-    scrollBottom(leaf: MarkdownView) {
+    jumpBottom(leaf: MarkdownView) {
         let scroll = this.getScroll(leaf);
         leaf.previewMode.applyScroll(scroll + this.settings.scrollDifference);
         let newScroll = this.getScroll(leaf);
@@ -127,52 +141,52 @@ export default class VimReadingViewNavigation extends Plugin {
         }
     }
 
-	async loadSettings() {
-		this.settings = Object.assign(
-			{},
-			DEFAULT_SETTINGS,
-			await this.loadData()
-		);
-	}
+    async loadSettings() {
+        this.settings = Object.assign(
+            {},
+            DEFAULT_SETTINGS,
+            await this.loadData()
+        );
+    }
 
-	async saveSettings() {
-		await this.saveData(this.settings);
-	}
+    async saveSettings() {
+        await this.saveData(this.settings);
+    }
 }
 
 class VimScrollSettingTab extends PluginSettingTab {
-	plugin: VimReadingViewNavigation;
+    plugin: VimReadingViewNavigation;
 
-	constructor(app: App, plugin: VimReadingViewNavigation) {
-		super(app, plugin);
-		this.plugin = plugin;
-	}
+    constructor(app: App, plugin: VimReadingViewNavigation) {
+        super(app, plugin);
+        this.plugin = plugin;
+    }
 
-	display(): void {
-		const { containerEl } = this;
-		const { settings } = this.plugin;
+    display(): void {
+        const { containerEl } = this;
+        const { settings } = this.plugin;
 
-		containerEl.empty();
+        containerEl.empty();
 
-		containerEl.createEl('h2', { text: 'Vim Reading View Navigation' });
+        containerEl.createEl('h2', { text: 'Vim Reading View Navigation' });
 
-		new Setting(containerEl)
-			.setName('Scroll amount')
-			.setDesc('It must be greater than 0.')
-			.addText((text) => {
-				text.setPlaceholder('Enter a number greater than 0. Default: 1')
-					.setValue(settings.scrollDifference.toString())
-					.onChange(async (value) => {
-						const num = Number.parseInt(value);
-						if (Number.isInteger(num) && num > 0) {
-							settings.scrollDifference = num;
-							await this.plugin.saveSettings();
-						} else {
-							new Notice(
-								'Please enter an integer greater than 0.'
-							);
-						}
-					});
-			});
-	}
+        new Setting(containerEl)
+            .setName('Scroll amount')
+            .setDesc('It must be greater than 0.')
+            .addText((text) => {
+                text.setPlaceholder('Enter a number greater than 0. Default: 1')
+                    .setValue(settings.scrollDifference.toString())
+                    .onChange(async (value) => {
+                        const num = Number.parseInt(value);
+                        if (Number.isInteger(num) && num > 0) {
+                            settings.scrollDifference = num;
+                            await this.plugin.saveSettings();
+                        } else {
+                            new Notice(
+                                'Please enter an integer greater than 0.'
+                            );
+                        }
+                    });
+            });
+    }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -69,7 +69,7 @@ export default class VimReadingViewNavigation extends Plugin {
                 }
             }
         }
-        addEventListener('keydown', jumpTopEvent, { capture: true });
+        addEventListener('keydown', jumpTopEvent);
 
         // Jump to bottom
         //  1st evt registers g when CapsLock is on
@@ -111,7 +111,7 @@ export default class VimReadingViewNavigation extends Plugin {
 
     async onunload() {
         app.keymap.popScope(this.navScope);
-        removeEventListener('keydown', this.jumpTopEvent, { capture: true });
+        removeEventListener('keydown', this.jumpTopEvent);
         console.log('Vim Reading View Navigation unloaded.');
     }
 


### PR DESCRIPTION
## Description of the Change
Added functionality to jump to top/bottom of the active note by pressing `g` and `G`, respectively.

## Checklist
- [X] Used the provided eslint configuration, [as explained in the Readme](README.md#Contribute).
- [X] Did *not* use prettier.
- [X] Used expressive variable names.
- [X] Code is commented well.
    - Changes are self-explanatory